### PR TITLE
Cancel context early to avoid notification to closed channel

### DIFF
--- a/broadcaster.go
+++ b/broadcaster.go
@@ -166,6 +166,7 @@ func (cs *channeledSender) supportsHaves() bool {
 
 func (cs *channeledSender) shutdown() {
 	cs.cancel()
+	cs.maxBatchWait.Stop()
 	close(cs.outgoing)
 }
 


### PR DESCRIPTION
Avoid potential panic by using the context with timeout in the hook callback function. The issue can occur when hook can still receive results while un-registeration request is yet to be processed.