### PR TITLE
Containerize `cassette` binary and add CI to publish images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,19 @@
+name: Build
+
+on: [ push, pull_request ]
+
+jobs:
+  build:
+    name: Container
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Container image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: false
+          platforms: linux/amd64

--- a/.github/workflows/publish-ecr.yml
+++ b/.github/workflows/publish-ecr.yml
@@ -1,0 +1,46 @@
+name: ECR
+
+on:
+  release:
+    types:
+      - published
+      - released
+  push:
+    branches:
+      - main
+
+jobs:
+  publisher:
+    if: ${{ github.event.pusher.name != 'sti-bot' }}
+    name: Publish
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      ECR_REGISTRY: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Determine Container Tag
+        run: |
+          IMAGE_TAG="${GITHUB_REF#refs/tags/v}"
+          if test "${IMAGE_TAG}" = "${GITHUB_REF}"; then
+            IMAGE_TAG="$(date '+%Y%m%d%H%M%S')-${GITHUB_SHA}"
+          fi
+          echo "Using image tag: ${IMAGE_TAG}"
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+      - name: AWS Login
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-2
+          role-to-assume: "arn:aws:iam::407967248065:role/common/github_actions"
+          role-duration-seconds: 1200
+      - name: Login to Amazon ECR
+        run: aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_REGISTRY}
+      - name: Publish Container Image
+        run: |
+          IMAGE_NAME="${ECR_REGISTRY}/cassette:${IMAGE_TAG}"
+          docker build -t "${IMAGE_NAME}" .
+          docker push "${IMAGE_NAME}"
+          echo "Published image ${IMAGE_NAME}"

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,0 +1,43 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+  release:
+    types:
+      - published
+      - released
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    name: Container
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          tags: |
+            type=semver,pattern={{version}}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.19-bullseye as build
+
+WORKDIR /go/src/cassette
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 go build -o /go/bin/cassette ./cmd/cassette
+
+FROM gcr.io/distroless/static-debian11
+COPY --from=build /go/bin/cassette /usr/bin/
+
+ENTRYPOINT ["/usr/bin/cassette"]


### PR DESCRIPTION
Add `Dockerfile` and CI jobs to build and publish images onto ghcr.io and AWS ECR repo.