### PR TITLE
Implement optional configuration via YAML file

### DIFF
--- a/broadcaster.go
+++ b/broadcaster.go
@@ -218,7 +218,7 @@ func (cs *channeledSender) sendUnsent() {
 func (b *broadcaster) newChanneledSender(id peer.ID) *channeledSender {
 	cs := channeledSender{
 		id:           id,
-		mailbox:      make(chan findCids, b.c.messageSenderBuffer),
+		mailbox:      make(chan findCids, b.c.broadcastSendChannelBuffer),
 		c:            b.c,
 		unsentCids:   make(map[cid.Cid]struct{}),
 		maxBatchSize: b.c.maxBroadcastBatchSize,

--- a/cassette.go
+++ b/cassette.go
@@ -77,7 +77,7 @@ func (c *Cassette) Find(ctx context.Context, k cid.Cid) chan peer.AddrInfo {
 	rch := make(chan peer.AddrInfo, 1)
 	go func() {
 		var resultCount atomic.Int64
-		ctx, cancel := context.WithTimeout(ctx, c.maxWaitTimeout)
+		ctx, cancel := context.WithTimeout(ctx, c.responseTimeout)
 		providersSoFar := make(map[peer.ID]struct{})
 		unregister := c.r.registerFoundHook(ctx, k, func(id peer.ID) {
 			if _, seen := providersSoFar[id]; seen {

--- a/cmd/cassette/internal/config.go
+++ b/cmd/cassette/internal/config.go
@@ -1,0 +1,194 @@
+package internal
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/ipfs/go-log/v2"
+	"github.com/ipni/cassette"
+	"github.com/libp2p/go-libp2p"
+	core_connmgr "github.com/libp2p/go-libp2p/core/connmgr"
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
+	"gopkg.in/yaml.v2"
+)
+
+var logger = log.Logger("cassette/cmd/config")
+
+type Config struct {
+	Libp2p *struct {
+		IdentityPath *string   `yaml:"identityPath"`
+		ListenAddrs  *[]string `yaml:"listenAddr"`
+		UserAgent    *string   `yaml:"userAgent"`
+		ConnManager  *struct {
+			HighWater     *int           `yaml:"highWater"`
+			LowWater      *int           `yaml:"lowWater"`
+			GracePeriod   *time.Duration `yaml:"gracePeriod"`
+			SilencePeriod *time.Duration `yaml:"silencePeriod"`
+			EmergencyTrim *bool          `yaml:"emergencyTrim"`
+		} `yaml:"connManager"`
+		ResourceManager *struct {
+			// TODO add resource manager config
+		} `yaml:"resourceManager"`
+	} `yaml:"libp2p"`
+	Ipni *struct {
+		HttpListenAddr           *string        `yaml:"httpListenAddr"`
+		HttpAllowOrigin          *string        `yaml:"httpAllowOrigin"`
+		PreferJsonResponse       *bool          `yaml:"preferJsonResponse"`
+		CascadeLabel             *string        `yaml:"cascadeLabel"`
+		RequireCascadeQueryParam *bool          `yaml:"requireCascadeQueryParam"`
+		ResponseTimeout          *time.Duration `yaml:"responseTimeout"`
+		FindByMultihash          *bool          `yaml:"findByMultihash"`
+		DisableAddrFilter        *bool          `yaml:"disableAddrFilter"`
+	} `yaml:"ipni"`
+	Metrics *struct {
+		ListenAddr       *string `yaml:"listenAddr"`
+		EnablePprofDebug *bool   `yaml:"enablePprofDebug"`
+	} `yaml:"metrics"`
+	Bitswap *struct {
+		Peers                      *[]string      `yaml:"peers"`
+		MaxBroadcastBatchSize      *int           `yaml:"maxBroadcastBatchSize"`
+		MaxBroadcastBatchWait      *time.Duration `yaml:"maxBroadcastBatchWait"`
+		FallbackOnWantBlock        *bool          `yaml:"fallbackOnWantBlock"`
+		RecipientsRefreshInterval  *time.Duration `yaml:"recipientsRefreshInterval"`
+		BroadcastSendChannelBuffer *int           `yaml:"sendChannelBuffer"`
+	} `yaml:"bitswap"`
+}
+
+func NewConfig(path string) (*Config, error) {
+	f, err := os.Open(filepath.Clean(path))
+	if err != nil {
+		return nil, err
+	}
+	var config Config
+	if err := yaml.NewDecoder(f).Decode(&config); err != nil {
+		return nil, err
+	}
+	return &config, nil
+}
+
+func (c *Config) ToOptions() ([]cassette.Option, error) {
+	var opts []cassette.Option
+	if c.Libp2p != nil {
+		var hOpts []libp2p.Option
+		userAgent := "ipni/cassette"
+		if c.Libp2p.UserAgent != nil {
+			userAgent = *c.Libp2p.UserAgent
+		}
+		libp2p.UserAgent(userAgent)
+		if c.Libp2p.IdentityPath != nil {
+			p := filepath.Clean(*c.Libp2p.IdentityPath)
+			logger := logger.With("path", p)
+			logger.Info("Unmarshalling libp2p host identity")
+			mid, err := os.ReadFile(p)
+			if err != nil {
+				logger.Errorw("Failed to read libp2p host identity file", "err", err)
+				return nil, err
+			}
+			id, err := crypto.UnmarshalPrivateKey(mid)
+			if err != nil {
+				logger.Errorw("Failed to unmarshal libp2p host identity file", "err", err)
+				return nil, err
+			}
+			hOpts = append(hOpts, libp2p.Identity(id))
+		}
+		if c.Libp2p.ListenAddrs != nil {
+			hOpts = append(hOpts, libp2p.ListenAddrStrings(*c.Libp2p.ListenAddrs...))
+		}
+		if c.Libp2p.ResourceManager == nil {
+			hOpts = append(hOpts, libp2p.ResourceManager(&network.NullResourceManager{}))
+		}
+		var cm core_connmgr.ConnManager
+		if c.Libp2p.ConnManager == nil {
+			cm = core_connmgr.NullConnMgr{}
+		} else {
+			low, high := 0xff, 0xfff
+			if c.Libp2p.ConnManager.LowWater != nil {
+				low = *c.Libp2p.ConnManager.LowWater
+			}
+			if c.Libp2p.ConnManager.HighWater != nil {
+				high = *c.Libp2p.ConnManager.HighWater
+			}
+			var cmOpts []connmgr.Option
+			if c.Libp2p.ConnManager.GracePeriod != nil {
+				cmOpts = append(cmOpts, connmgr.WithGracePeriod(*c.Libp2p.ConnManager.GracePeriod))
+			}
+			if c.Libp2p.ConnManager.SilencePeriod != nil {
+				cmOpts = append(cmOpts, connmgr.WithSilencePeriod(*c.Libp2p.ConnManager.SilencePeriod))
+			}
+			if c.Libp2p.ConnManager.EmergencyTrim != nil {
+				cmOpts = append(cmOpts, connmgr.WithEmergencyTrim(*c.Libp2p.ConnManager.EmergencyTrim))
+			}
+			var err error
+			cm, err = connmgr.NewConnManager(low, high, cmOpts...)
+			if err != nil {
+				logger.Errorw("Failed to instantiate connection manager", "err", err)
+				return nil, err
+			}
+		}
+		hOpts = append(hOpts, libp2p.ConnectionManager(cm))
+		h, err := libp2p.New(hOpts...)
+		if err != nil {
+			logger.Errorw("Failed to instantiate libp2p host", "err", err)
+			return nil, err
+		}
+		opts = append(opts, cassette.WithHost(h))
+	}
+	if c.Ipni != nil {
+		if c.Ipni.HttpListenAddr != nil {
+			opts = append(opts, cassette.WithHttpListenAddr(*c.Ipni.HttpListenAddr))
+		}
+		if c.Ipni.HttpAllowOrigin != nil {
+			opts = append(opts, cassette.WithHttpAllowOrigin(*c.Ipni.HttpAllowOrigin))
+		}
+		if c.Ipni.PreferJsonResponse != nil {
+			opts = append(opts, cassette.WithHttpResponsePreferJson(*c.Ipni.PreferJsonResponse))
+		}
+		if c.Ipni.CascadeLabel != nil {
+			opts = append(opts, cassette.WithIpniCascadeLabel(*c.Ipni.CascadeLabel))
+		}
+		if c.Ipni.RequireCascadeQueryParam != nil {
+			opts = append(opts, cassette.WithIpniRequireCascadeQueryParam(*c.Ipni.RequireCascadeQueryParam))
+		}
+		if c.Ipni.ResponseTimeout != nil {
+			opts = append(opts, cassette.WithResponseTimeout(*c.Ipni.ResponseTimeout))
+		}
+		if c.Ipni.FindByMultihash != nil {
+			opts = append(opts, cassette.WithFindByMultihash(*c.Ipni.FindByMultihash))
+		}
+		if c.Ipni.DisableAddrFilter != nil {
+			opts = append(opts, cassette.WithDisableAddrFilter(*c.Ipni.DisableAddrFilter))
+		}
+	}
+	if c.Metrics != nil {
+		if c.Metrics.ListenAddr != nil {
+			opts = append(opts, cassette.WithMetricsListenAddr(*c.Metrics.ListenAddr))
+		}
+		if c.Metrics.EnablePprofDebug != nil {
+			opts = append(opts, cassette.WithMetricsEnablePprofDebug(*c.Metrics.EnablePprofDebug))
+		}
+	}
+	if c.Bitswap != nil {
+		if c.Bitswap.Peers != nil {
+			opts = append(opts, cassette.WithPeerStrings(*c.Bitswap.Peers...))
+		}
+		if c.Bitswap.MaxBroadcastBatchSize != nil {
+			opts = append(opts, cassette.WithMaxBroadcastBatchSize(*c.Bitswap.MaxBroadcastBatchSize))
+		}
+		if c.Bitswap.MaxBroadcastBatchWait != nil {
+			opts = append(opts, cassette.WithMaxBroadcastBatchWait(*c.Bitswap.MaxBroadcastBatchWait))
+		}
+		if c.Bitswap.FallbackOnWantBlock != nil {
+			opts = append(opts, cassette.WithFallbackOnWantBlock(*c.Bitswap.FallbackOnWantBlock))
+		}
+		if c.Bitswap.RecipientsRefreshInterval != nil {
+			opts = append(opts, cassette.WithRecipientsRefreshInterval(*c.Bitswap.RecipientsRefreshInterval))
+		}
+		if c.Bitswap.BroadcastSendChannelBuffer != nil {
+			opts = append(opts, cassette.WithBroadcastSendChannelBuffer(*c.Bitswap.BroadcastSendChannelBuffer))
+		}
+	}
+	return opts, nil
+}

--- a/cmd/cassette/main.go
+++ b/cmd/cassette/main.go
@@ -5,31 +5,16 @@ import (
 	"flag"
 	"os"
 	"os/signal"
-	"path/filepath"
-	"strings"
 
 	"github.com/ipfs/go-log/v2"
 	"github.com/ipni/cassette"
-	"github.com/libp2p/go-libp2p"
-	"github.com/libp2p/go-libp2p/core/crypto"
-	"github.com/libp2p/go-libp2p/core/network"
-	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
+	"github.com/ipni/cassette/cmd/cassette/internal"
 )
 
 var logger = log.Logger("cassette/cmd")
 
-const libp2pUserAgent = "ipni/cassette"
-
 func main() {
-	libp2pIdentityPath := flag.String("libp2pIdentityPath", "", "The path to the marshalled libp2p host identity. If unspecified a random identity is generated.")
-	libp2pListenAddrs := flag.String("libp2pListenAddrs", "", "The comma separated libp2p host listen multiaddrs. If unspecified the default listen multiaddrs are used at ephemeral port.")
-	libp2pConMgrLow := flag.Int("libp2pConMgrLow", 160, "The low watermark of libp2p connection manager.")
-	libp2pConMgrHigh := flag.Int("libp2pConMgrHigh", 192, "The high watermark of libp2p connection manager.")
-	httpListenAddr := flag.String("httpListenAddr", "0.0.0.0:40080", "The cassette HTTP server listen address in address:port format.")
-	httpResponsePreferJson := flag.Bool("httpResponsePreferJson", false, `Whether to prefer responding with JSON instead of NDJSON when Accept header is set to "*/*".`)
-	useResourceManager := flag.Bool("useResourceManager", true, "Weather to use resource manager with built-in increased limits. When disabled Resource Manager is completely disabled.")
-	ipniRequireQueryParam := flag.Bool("ipniRequireQueryParam", false, `Weather to require IPNI "cascade" query parameter with matching label in order to respond to HTTP lookup requests. Not required by default.`)
-	ipniCascadeLabel := flag.String("ipniCascadeLabel", "legacy", "The IPNI cascade label associated to this instance.")
+	config := flag.String("config", "", "Path to config YAML file. If unspecified, default config will be used.")
 	logLevel := flag.String("logLevel", "info", "The logging level. Only applied if GOLOG_LOG_LEVEL environment variable is unset.")
 	flag.Parse()
 
@@ -37,47 +22,20 @@ func main() {
 		_ = log.SetLogLevel("*", *logLevel)
 		_ = log.SetLogLevel("net/identify", "error")
 	}
-
-	hOpts := []libp2p.Option{
-		libp2p.UserAgent(libp2pUserAgent),
-	}
-	if *libp2pIdentityPath != "" {
-		p := filepath.Clean(*libp2pIdentityPath)
-		logger := logger.With("path", p)
-		logger.Info("Unmarshalling libp2p host identity")
-		mid, err := os.ReadFile(p)
+	*config = "config.yaml"
+	var opts []cassette.Option
+	if *config != "" {
+		cfg, err := internal.NewConfig(*config)
 		if err != nil {
-			logger.Fatalw("Failed to read libp2p host identity file", "err", err)
+			logger.Fatalw("Failed to instantiate config from path", "path", *config, "err", err)
 		}
-		id, err := crypto.UnmarshalPrivateKey(mid)
+		opts, err = cfg.ToOptions()
 		if err != nil {
-			logger.Fatalw("Failed to unmarshal libp2p host identity file", "err", err)
+			logger.Fatalw("Failed parse config to options", "err", err)
 		}
-		hOpts = append(hOpts, libp2p.Identity(id))
-	}
-	if *libp2pListenAddrs != "" {
-		hOpts = append(hOpts, libp2p.ListenAddrStrings(strings.Split(*libp2pListenAddrs, ",")...))
-	}
-	if !*useResourceManager {
-		hOpts = append(hOpts, libp2p.ResourceManager(&network.NullResourceManager{}))
-	}
-	cmngr, err := connmgr.NewConnManager(*libp2pConMgrLow, *libp2pConMgrHigh)
-	if err != nil {
-		logger.Fatalw("Failed to instantiate connection manager", "err", err)
-	}
-	hOpts = append(hOpts, libp2p.ConnectionManager(cmngr))
-	h, err := libp2p.New(hOpts...)
-	if err != nil {
-		logger.Fatalw("Failed to instantiate libp2p host", "err", err)
 	}
 
-	c, err := cassette.New(
-		cassette.WithHost(h),
-		cassette.WithHttpListenAddr(*httpListenAddr),
-		cassette.WithHttpResponsePreferJson(*httpResponsePreferJson),
-		cassette.WithIpniRequireCascadeQueryParam(*ipniRequireQueryParam),
-		cassette.WithIpniCascadeLabel(*ipniCascadeLabel),
-	)
+	c, err := cassette.New(opts...)
 	if err != nil {
 		logger.Fatalw("Failed to instantiate cassette", "err", err)
 	}

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,0 +1,45 @@
+libp2p:
+  # Unspecified identityPath results in random peer identity generation.
+  # identityPath: '<path-to-identity-key>'
+  listenAddr:
+    - /ip4/0.0.0.0/tcp/40090
+    - /ip4/0.0.0.0/udp/40090/quic
+    - /ip4/0.0.0.0/udp/40090/quic-v1
+  userAgent: ipni/cassette
+  # To disable the connection manger set `connManager` to `null`.
+  connManager:
+    lowWater: 500
+    highWater: 5000
+    gracePeriod: 20s
+    silencePeriod: 10s
+    emergencyTrim: true
+  # Disable resource manager by setting it to null
+  # To enable default resource manger, set the value to non-nil, e.g. {}
+  resourceManager: null
+ipni:
+  httpListenAddr: 0.0.0.0:40080
+  httpAllowOrigin: '*'
+  preferJsonResponse: false
+  cascadeLabel: legacy
+  requireCascadeQueryParam: true
+  responseTimeout: 5s
+  findByMultihash: true
+  disableAddrFilter: false
+metrics:
+  listenAddr: 0.0.0.0:40081
+  enablePprofDebug: true
+bitswap:
+  peers:
+    - '/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN'
+    - '/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa'
+    - '/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb'
+    - '/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt'
+    # mars.i.ipfs.io
+    - '/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ'
+    # mars.i.ipfs.io
+    - '/ip4/104.131.131.82/udp/4001/quic/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ'
+  maxBroadcastBatchSize: 100
+  maxBroadcastBatchWait: 100ms
+  fallbackOnWantBlock: true
+  recipientsRefreshInterval: 10s
+  sendChannelBuffer: 100

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	go.opentelemetry.io/otel/exporters/prometheus v0.37.0
 	go.opentelemetry.io/otel/metric v0.37.0
 	go.opentelemetry.io/otel/sdk/metric v0.37.0
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (


### PR DESCRIPTION
The amount of configurable parameters for `cassette` are too many to create flag for each.

Instead, implement YAML based config file that can be used to configure all parameters. The choice of YAML is to allow writing comment in the config file while having a human readable format.