### PR TITLE
Fix in-flight time reset

### DIFF
--- a/broadcaster.go
+++ b/broadcaster.go
@@ -187,6 +187,9 @@ func (cs *channeledSender) shutdown() {
 }
 
 func (cs *channeledSender) sendUnsent() {
+	defer func() {
+		cs.unsentTimestamp = time.Now()
+	}()
 	var wantHave bool
 	cidCount := int64(len(cs.unsentCids))
 	var wlt bitswap_message_pb.Message_Wantlist_WantType


### PR DESCRIPTION
Fix a bug where in-flight time metrics was not capturing the timing correctly since after a broadcast the timestamp was never reset.