### PR TITLE
Delete recipients on Circuit breaker opening

### DIFF
--- a/broadcaster.go
+++ b/broadcaster.go
@@ -258,6 +258,11 @@ func (b *broadcaster) newChanneledSender(id peer.ID) *channeledSender {
 		circuitbreaker.WithOnStateChangeHookFn(func(from, to circuitbreaker.State) {
 			b.c.metrics.notifyBroadcastRecipientCBStateChanged(cs.ctx, id, from, to)
 			logger.Infow("Broadcast recipient circuit breaker state changed", "recipient", id, "from", from, "to", to)
+			switch to {
+			case circuitbreaker.StateOpen:
+				b.mailbox <- removeRecipient{id: id}
+				logger.Warnw("Removing recipient with opened circuit breaker", "recipient", id, "from", from, "to", to)
+			}
 		}),
 	)
 	return &cs


### PR DESCRIPTION
When a peered node changes address or is no longer accessible it remains in the list of recipients indefinitely with circuit breaker ping ponging between different states until the pod is restarted.

The changes here remove a recipient if it misbehaves such that it opens a the circuit breaker. The sensitivity to misbehaviour is then configurable by setting circuit breaker open/half-open characteristics.

The recipients of broadcast are expected to peer with Cassette. Peering attempts to re-connect periodically. So as long as recipients have peered with Cassete they should get re-added as normal.