### PR TITLE
Cancel `WANT-*` request within a configurable timeout

### DIFF
--- a/cmd/cassette/internal/config.go
+++ b/cmd/cassette/internal/config.go
@@ -78,6 +78,7 @@ type Config struct {
 			Constant *time.Duration `yaml:"constant"`
 		} `yaml:"recipientCBOpenTimeoutBackOff"`
 		RecipientCBOpenTimeout *time.Duration `yaml:"recipientCBOpenTimeout"`
+		BroadcastCancelAfter   *time.Duration `yaml:"broadcastCancelAfter"`
 	} `yaml:"bitswap"`
 }
 
@@ -259,6 +260,9 @@ func (c *Config) ToOptions() ([]cassette.Option, error) {
 		}
 		if c.Bitswap.RecipientCBOpenTimeout != nil {
 			opts = append(opts, cassette.WithRecipientCBOpenTimeout(*c.Bitswap.RecipientCBOpenTimeout))
+		}
+		if c.Bitswap.BroadcastCancelAfter != nil {
+			opts = append(opts, cassette.WithBroadcastCancelAfter(*c.Bitswap.BroadcastCancelAfter))
 		}
 	}
 	return opts, nil

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -53,3 +53,4 @@ bitswap:
   recipientCBOpenTimeout: 1s
   recipientCBOpenTimeoutBackOff:
     exponential: {}
+  broadcastCancelAfter: 5s

--- a/options.go
+++ b/options.go
@@ -46,6 +46,8 @@ type (
 		fallbackOnWantBlock          bool
 		addrFilterDisabled           bool
 
+		broadcastCancelAfter time.Duration
+
 		recipientCBTripFunc              circuitbreaker.TripFunc
 		recipientCBCounterResetInterval  time.Duration
 		recipientCBFailOnContextCancel   bool
@@ -79,6 +81,7 @@ func newOptions(o ...Option) (*options, error) {
 		maxBroadcastBatchWait:      100 * time.Millisecond,
 		peerDiscoveryInterval:      10 * time.Second,
 		peerDiscoveryAddrTTL:       10 * time.Minute,
+		broadcastCancelAfter:       5 * time.Second,
 
 		recipientCBTripFunc:              circuitbreaker.NewTripFuncConsecutiveFailures(3),
 		recipientCBCounterResetInterval:  2 * time.Second,
@@ -334,6 +337,13 @@ func WithRecipientCBOpenTimeoutBackOff(b backoff.BackOff) Option {
 func WithRecipientCBOpenTimeout(t time.Duration) Option {
 	return func(o *options) error {
 		o.recipientCBOpenTimeout = t
+		return nil
+	}
+}
+
+func WithBroadcastCancelAfter(t time.Duration) Option {
+	return func(o *options) error {
+		o.broadcastCancelAfter = t
 		return nil
 	}
 }


### PR DESCRIPTION
Implement cancellation broadcast, where CIDs for which `WANT-*` is broadcasted are cancelled after some configurable duration. This would help reduce the chances of content discovery failure caused by the unconfigurable limit of 1024 want-list in Kubo introduced in "ledger inversion".

Extend metrics to report number of CIDs broadcasted tagged by status such that in the successful broadcast the cancellation CID count is also reported.

Relates to:
 - https://github.com/ipfs/boxo/commit/9cb5cb54d40b57084d1221ba83b9e6bb3fcc3197