### PR TITLE
Check context while adding CIDs to broadcast list

### DIFF
--- a/broadcaster.go
+++ b/broadcaster.go
@@ -300,6 +300,11 @@ func (b *broadcaster) newChanneledSender(id peer.ID) *channeledSender {
 	return &cs
 }
 
-func (b *broadcaster) broadcastWant(c []cid.Cid) {
-	b.mailbox <- findCids{cids: c, timestamp: time.Now()}
+func (b *broadcaster) broadcastWant(ctx context.Context, c []cid.Cid) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case b.mailbox <- findCids{cids: c, timestamp: time.Now()}:
+		return nil
+	}
 }

--- a/cassette.go
+++ b/cassette.go
@@ -110,8 +110,9 @@ func (c *Cassette) Find(ctx context.Context, k cid.Cid) chan peer.AddrInfo {
 			close(rch)
 		}()
 		targets := c.toFindTargets(k)
-		c.broadcaster.broadcastWant(targets)
-		<-ctx.Done()
+		if err := c.broadcaster.broadcastWant(ctx, targets); err == nil {
+			<-ctx.Done()
+		}
 		c.metrics.notifyLookupResponded(context.Background(), resultCount.Load(), timeToFirstProvider, time.Since(start))
 		// TODO add option to stop based on provider count limit
 	}()


### PR DESCRIPTION
If broadcast channel is congested and lookup request continue to flow then lookup will start leaking goroutines. To fix this, give up handling the lookup request if we cannot broadcast CID in time.