### PR TITLE
Add send total timeout and use dedicated context for metrics

### DIFF
--- a/cassette.go
+++ b/cassette.go
@@ -77,7 +77,7 @@ func (c *Cassette) Start(ctx context.Context) error {
 
 func (c *Cassette) Find(ctx context.Context, k cid.Cid) chan peer.AddrInfo {
 	start := time.Now()
-	c.metrics.notifyLookupRequested(ctx)
+	c.metrics.notifyLookupRequested(context.Background())
 	var timeToFirstProvider time.Duration
 	rch := make(chan peer.AddrInfo, 1)
 	go func() {

--- a/cmd/cassette/internal/config.go
+++ b/cmd/cassette/internal/config.go
@@ -55,6 +55,7 @@ type Config struct {
 		MaxBroadcastBatchWait      *time.Duration `yaml:"maxBroadcastBatchWait"`
 		FallbackOnWantBlock        *bool          `yaml:"fallbackOnWantBlock"`
 		RecipientsRefreshInterval  *time.Duration `yaml:"recipientsRefreshInterval"`
+		BroadcastChannelBuffer     *int           `yaml:"broadcastChannelBuffer"`
 		BroadcastSendChannelBuffer *int           `yaml:"sendChannelBuffer"`
 		PeerDiscoveryInterval      *time.Duration `yaml:"peerDiscoveryInterval"`
 		PeerDiscoveryAddrTTL       *time.Duration `yaml:"peerDiscoveryAddrTTL"`
@@ -78,6 +79,7 @@ type Config struct {
 			Constant *time.Duration `yaml:"constant"`
 		} `yaml:"recipientCBOpenTimeoutBackOff"`
 		RecipientCBOpenTimeout *time.Duration `yaml:"recipientCBOpenTimeout"`
+		RecipientSendTimeout   *time.Duration `yaml:"recipientSendTimeout"`
 		BroadcastCancelAfter   *time.Duration `yaml:"broadcastCancelAfter"`
 	} `yaml:"bitswap"`
 }
@@ -214,6 +216,9 @@ func (c *Config) ToOptions() ([]cassette.Option, error) {
 		if c.Bitswap.BroadcastSendChannelBuffer != nil {
 			opts = append(opts, cassette.WithBroadcastSendChannelBuffer(*c.Bitswap.BroadcastSendChannelBuffer))
 		}
+		if c.Bitswap.BroadcastChannelBuffer != nil {
+			opts = append(opts, cassette.WithBroadcastChannelBuffer(*c.Bitswap.BroadcastChannelBuffer))
+		}
 		if c.Bitswap.PeerDiscoveryInterval != nil {
 			opts = append(opts, cassette.WithPeerDiscoveryInterval(*c.Bitswap.PeerDiscoveryInterval))
 		}
@@ -263,6 +268,9 @@ func (c *Config) ToOptions() ([]cassette.Option, error) {
 		}
 		if c.Bitswap.BroadcastCancelAfter != nil {
 			opts = append(opts, cassette.WithBroadcastCancelAfter(*c.Bitswap.BroadcastCancelAfter))
+		}
+		if c.Bitswap.RecipientSendTimeout != nil {
+			opts = append(opts, cassette.WithRecipientSendTimeout(*c.Bitswap.RecipientSendTimeout))
 		}
 	}
 	return opts, nil

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -52,5 +52,6 @@ bitswap:
   recipientCBHalfOpenMaxSuccesses: 10
   recipientCBOpenTimeout: 1s
   recipientCBOpenTimeoutBackOff:
-    exponential: {}
+    exponential: { }
+  recipientSendTimeout: 5s
   broadcastCancelAfter: 5s

--- a/options.go
+++ b/options.go
@@ -41,6 +41,7 @@ type (
 		ipniRequireCascadeQueryParam bool
 		responseTimeout              time.Duration
 		findByMultihash              bool
+		broadcastChannelBuffer       int
 		broadcastSendChannelBuffer   int
 		recipientsRefreshInterval    time.Duration
 		fallbackOnWantBlock          bool
@@ -55,6 +56,7 @@ type (
 		recipientCBHalfOpenMaxSuccesses  int64
 		recipientCBOpenTimeoutBackOff    backoff.BackOff
 		recipientCBOpenTimeout           time.Duration
+		recipientSendTimeout             time.Duration
 
 		maxBroadcastBatchSize int
 		maxBroadcastBatchWait time.Duration
@@ -73,6 +75,7 @@ func newOptions(o ...Option) (*options, error) {
 		ipniCascadeLabel:           "legacy",
 		httpAllowOrigin:            "*",
 		responseTimeout:            5 * time.Second,
+		broadcastChannelBuffer:     100,
 		broadcastSendChannelBuffer: 100,
 		findByMultihash:            true,
 		recipientsRefreshInterval:  10 * time.Second,
@@ -90,6 +93,7 @@ func newOptions(o ...Option) (*options, error) {
 		recipientCBHalfOpenMaxSuccesses:  5,
 		recipientCBOpenTimeoutBackOff:    circuitbreaker.DefaultOpenBackOff(),
 		recipientCBOpenTimeout:           5 * time.Second,
+		recipientSendTimeout:             5 * time.Second,
 	}
 	for _, apply := range o {
 		if err := apply(&opts); err != nil {
@@ -236,6 +240,13 @@ func WithBroadcastSendChannelBuffer(b int) Option {
 	}
 }
 
+func WithBroadcastChannelBuffer(b int) Option {
+	return func(o *options) error {
+		o.broadcastChannelBuffer = b
+		return nil
+	}
+}
+
 func WithFallbackOnWantBlock(b bool) Option {
 	return func(o *options) error {
 		o.fallbackOnWantBlock = b
@@ -344,6 +355,13 @@ func WithRecipientCBOpenTimeout(t time.Duration) Option {
 func WithBroadcastCancelAfter(t time.Duration) Option {
 	return func(o *options) error {
 		o.broadcastCancelAfter = t
+		return nil
+	}
+}
+
+func WithRecipientSendTimeout(t time.Duration) Option {
+	return func(o *options) error {
+		o.recipientSendTimeout = t
 		return nil
 	}
 }

--- a/receiver.go
+++ b/receiver.go
@@ -57,7 +57,7 @@ func newReceiver(c *Cassette) (*receiver, error) {
 				}
 				switch ee := e.(type) {
 				case receivedMessageEvent:
-					c.metrics.notifyReceiverMessageReceived(r.ctx, ee.from)
+					c.metrics.notifyReceiverMessageReceived(context.Background(), ee.from)
 					hooks, ok := registry[ee.k]
 					if ok && hooks != nil {
 						for _, hook := range hooks {
@@ -157,17 +157,17 @@ func (r *receiver) ReceiveMessage(ctx context.Context, sender peer.ID, in messag
 func (r *receiver) ReceiveError(err error) {
 	// TODO hook this up to circuit breakers?
 	logger.Errorw("Received Error", "err", err)
-	r.c.metrics.notifyReceiverErrored(r.ctx, err)
+	r.c.metrics.notifyReceiverErrored(context.Background(), err)
 }
 
 func (r *receiver) PeerConnected(id peer.ID) {
 	logger.Debugw("peer connected", "id", id)
-	r.c.metrics.notifyReceiverConnected(r.ctx)
+	r.c.metrics.notifyReceiverConnected(context.Background())
 }
 
 func (r *receiver) PeerDisconnected(id peer.ID) {
 	logger.Debugw("peer disconnected", "id", id)
-	r.c.metrics.notifyReceiverDisconnected(r.ctx)
+	r.c.metrics.notifyReceiverDisconnected(context.Background())
 }
 
 func (r *receiver) registerFoundHook(ctx context.Context, k cid.Cid, f func(id peer.ID)) func() {


### PR DESCRIPTION
Add a total timeout for a single cycle of broadcast. This is to make sure that the entire broadcast batch is either sent or wiped clean if it cannot be sent. The previous mechanism had timeouts implicitly inside bitswap implementation. The changes here add an explicit timeout to the context used across send.

Use a separate background context for metrics to assure that metrics are collected even if context expires. This is to avoid room for odd numbers being reported by metrics.