### PR TITLE
Revert "Parameterize receiver channel buffer"

### DIFF
--- a/cmd/cassette/internal/config.go
+++ b/cmd/cassette/internal/config.go
@@ -56,7 +56,6 @@ type Config struct {
 		FallbackOnWantBlock        *bool          `yaml:"fallbackOnWantBlock"`
 		RecipientsRefreshInterval  *time.Duration `yaml:"recipientsRefreshInterval"`
 		BroadcastChannelBuffer     *int           `yaml:"broadcastChannelBuffer"`
-		ReceiverChannelBuffer      *int           `yaml:"receiverChannelBuffer"`
 		BroadcastSendChannelBuffer *int           `yaml:"sendChannelBuffer"`
 		PeerDiscoveryInterval      *time.Duration `yaml:"peerDiscoveryInterval"`
 		PeerDiscoveryAddrTTL       *time.Duration `yaml:"peerDiscoveryAddrTTL"`
@@ -219,9 +218,6 @@ func (c *Config) ToOptions() ([]cassette.Option, error) {
 		}
 		if c.Bitswap.BroadcastChannelBuffer != nil {
 			opts = append(opts, cassette.WithBroadcastChannelBuffer(*c.Bitswap.BroadcastChannelBuffer))
-		}
-		if c.Bitswap.ReceiverChannelBuffer != nil {
-			opts = append(opts, cassette.WithReceiverChannelBuffer(*c.Bitswap.ReceiverChannelBuffer))
 		}
 		if c.Bitswap.PeerDiscoveryInterval != nil {
 			opts = append(opts, cassette.WithPeerDiscoveryInterval(*c.Bitswap.PeerDiscoveryInterval))

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -55,4 +55,3 @@ bitswap:
     exponential: { }
   recipientSendTimeout: 5s
   broadcastCancelAfter: 5s
-  receiverChannelBuffer: 100

--- a/options.go
+++ b/options.go
@@ -64,8 +64,6 @@ type (
 		peerDiscoveryHost     host.Host
 		peerDiscoveryInterval time.Duration
 		peerDiscoveryAddrTTL  time.Duration
-
-		receiverChannelBuffer int
 	}
 )
 
@@ -96,7 +94,6 @@ func newOptions(o ...Option) (*options, error) {
 		recipientCBOpenTimeoutBackOff:    circuitbreaker.DefaultOpenBackOff(),
 		recipientCBOpenTimeout:           5 * time.Second,
 		recipientSendTimeout:             5 * time.Second,
-		receiverChannelBuffer:            100,
 	}
 	for _, apply := range o {
 		if err := apply(&opts); err != nil {
@@ -365,13 +362,6 @@ func WithBroadcastCancelAfter(t time.Duration) Option {
 func WithRecipientSendTimeout(t time.Duration) Option {
 	return func(o *options) error {
 		o.recipientSendTimeout = t
-		return nil
-	}
-}
-
-func WithReceiverChannelBuffer(l int) Option {
-	return func(o *options) error {
-		o.receiverChannelBuffer = l
 		return nil
 	}
 }

--- a/receiver.go
+++ b/receiver.go
@@ -40,7 +40,7 @@ func newReceiver(c *Cassette) (*receiver, error) {
 	var r receiver
 	r.ctx, r.cancel = context.WithCancel(context.Background())
 	r.c = c
-	r.mailbox = make(chan any, c.receiverChannelBuffer)
+	r.mailbox = make(chan any)
 	go func() {
 		type registeredHook struct {
 			id   int64


### PR DESCRIPTION
With the channel based registered hook, receiver mailbox must operate via an unbuffered channel
Reverts ipni/cassette#34