### PR TITLE
Implement configurable provider record caching

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,60 @@
+package cassette
+
+import (
+	"time"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+type (
+	cache struct {
+		c     *Cassette
+		cache *lru.TwoQueueCache[string, cacheRecord]
+	}
+	cacheRecord struct {
+		insertedAt time.Time
+		providers  []peer.AddrInfo
+		//TODO: optimize cache memory consumption by deduplication of addrinfos.
+	}
+)
+
+func newCache(c *Cassette) (*cache, error) {
+	twoq, err := lru.New2Q[string, cacheRecord](c.cacheSize)
+	if err != nil {
+		return nil, err
+	}
+	return &cache{
+		c:     c,
+		cache: twoq,
+	}, nil
+}
+
+func (l *cache) getProviders(c cid.Cid) ([]peer.AddrInfo, bool) {
+	value, ok := l.cache.Get(string(c.Hash()))
+	switch {
+	case !ok:
+		return nil, false
+	case time.Since(value.insertedAt) > l.c.cacheExpiry:
+		l.expire(c)
+		return nil, false
+	default:
+		return value.providers, true
+	}
+}
+
+func (l *cache) putProviders(c cid.Cid, providers []peer.AddrInfo) {
+	l.cache.Add(string(c.Hash()), cacheRecord{
+		insertedAt: time.Now(),
+		providers:  providers,
+	})
+}
+
+func (l *cache) expire(c cid.Cid) {
+	l.cache.Remove(string(c.Hash()))
+}
+
+func (l *cache) len() int {
+	return l.cache.Len()
+}

--- a/cmd/cassette/internal/config.go
+++ b/cmd/cassette/internal/config.go
@@ -82,6 +82,10 @@ type Config struct {
 		RecipientSendTimeout   *time.Duration `yaml:"recipientSendTimeout"`
 		BroadcastCancelAfter   *time.Duration `yaml:"broadcastCancelAfter"`
 	} `yaml:"bitswap"`
+	Cache *struct {
+		Size   *int           `yaml:"size"`
+		Expiry *time.Duration `yaml:"expiry"`
+	} `yaml:"cache"`
 }
 
 func NewConfig(path string) (*Config, error) {
@@ -271,6 +275,14 @@ func (c *Config) ToOptions() ([]cassette.Option, error) {
 		}
 		if c.Bitswap.RecipientSendTimeout != nil {
 			opts = append(opts, cassette.WithRecipientSendTimeout(*c.Bitswap.RecipientSendTimeout))
+		}
+	}
+	if c.Cache != nil {
+		if c.Cache.Expiry != nil {
+			opts = append(opts, cassette.WithCacheExpiry(*c.Cache.Expiry))
+		}
+		if c.Cache.Size != nil {
+			opts = append(opts, cassette.WithCacheSize(*c.Cache.Size))
 		}
 	}
 	return opts, nil

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -55,3 +55,6 @@ bitswap:
     exponential: { }
   recipientSendTimeout: 5s
   broadcastCancelAfter: 5s
+cache:
+  expiry: 1h
+  size: 1000

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/cenkalti/backoff/v3 v3.1.1
+	github.com/hashicorp/golang-lru/v2 v2.0.3
 	github.com/ipfs/boxo v0.8.1
 	github.com/ipfs/go-cid v0.4.0
 	github.com/ipfs/go-log/v2 v2.5.1

--- a/go.sum
+++ b/go.sum
@@ -237,6 +237,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.3 h1:kmRrRLlInXvng0SmLxmQpQkpbYAvcXm7NPDrgxJa9mE=
+github.com/hashicorp/golang-lru/v2 v2.0.3/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/huin/goupnp v1.0.0/go.mod h1:n9v9KO1tAxYH82qOn+UTIFQDmx5n1Zxd/ClZDMX7Bnc=
 github.com/huin/goupnp v1.0.3 h1:N8No57ls+MnjlB+JPiCVSOyy/ot7MJTqlo7rn+NYSqQ=
 github.com/huin/goupnp v1.0.3/go.mod h1:ZxNlw5WqJj6wSsRK5+YfflQGXYfccj5VgQsMNixHM7Y=

--- a/options.go
+++ b/options.go
@@ -64,6 +64,9 @@ type (
 		peerDiscoveryHost     host.Host
 		peerDiscoveryInterval time.Duration
 		peerDiscoveryAddrTTL  time.Duration
+
+		cacheExpiry time.Duration
+		cacheSize   int
 	}
 )
 
@@ -94,6 +97,8 @@ func newOptions(o ...Option) (*options, error) {
 		recipientCBOpenTimeoutBackOff:    circuitbreaker.DefaultOpenBackOff(),
 		recipientCBOpenTimeout:           5 * time.Second,
 		recipientSendTimeout:             5 * time.Second,
+		cacheExpiry:                      time.Hour,
+		cacheSize:                        1_000,
 	}
 	for _, apply := range o {
 		if err := apply(&opts); err != nil {
@@ -362,6 +367,20 @@ func WithBroadcastCancelAfter(t time.Duration) Option {
 func WithRecipientSendTimeout(t time.Duration) Option {
 	return func(o *options) error {
 		o.recipientSendTimeout = t
+		return nil
+	}
+}
+
+func WithCacheExpiry(t time.Duration) Option {
+	return func(o *options) error {
+		o.cacheExpiry = t
+		return nil
+	}
+}
+
+func WithCacheSize(s int) Option {
+	return func(o *options) error {
+		o.cacheSize = s
 		return nil
 	}
 }


### PR DESCRIPTION
Implement caching mechanism where the entire found provider record is cached regardless of the peerstore state.

Use an adaptive 2Q cache heuristic where burst of unseen keys will not impact popular cache entries.